### PR TITLE
Clusters keep track of their centroids

### DIFF
--- a/include/Objects/Cluster.h
+++ b/include/Objects/Cluster.h
@@ -407,7 +407,7 @@ private:
 		SimplePoint() : m_xyzPosition(0.f,0.f,0.f), m_nHits(0) {}
     };
 
-    typedef std::map<unsigned int, SimplePoint> PointByPseudoLayerMap;///< The point by pseudo layer typedef
+    typedef std::vector<SimplePoint> PointByPseudoLayerMap;     ///< The point by pseudo layer typedef
     typedef std::map<HitType, float> HitTypeToEnergyMap;        ///< The hit type to energy map typedef
 
     OrderedCaloHitList          m_orderedCaloHitList;           ///< The ordered calo hit list

--- a/include/Objects/Cluster.h
+++ b/include/Objects/Cluster.h
@@ -405,7 +405,7 @@ private:
         unsigned int            m_nHits;                        ///< The number of hits in the pseudo layer
     };
 
-    typedef std::vector<SimplePoint> PointByPseudoLayerMap;     ///< The point by pseudo layer typedef
+    typedef std::map<unsigned int, SimplePoint> PointByPseudoLayerMap;///< The point by pseudo layer typedef
     typedef std::map<HitType, float> HitTypeToEnergyMap;        ///< The hit type to energy map typedef
 
     OrderedCaloHitList          m_orderedCaloHitList;           ///< The ordered calo hit list

--- a/include/Objects/Cluster.h
+++ b/include/Objects/Cluster.h
@@ -149,7 +149,7 @@ public:
      * 
      *  @return The unweighted centroid, returned by value
      */
-    const CartesianVector GetCentroid(const unsigned int pseudoLayer) const;
+    const CartesianVector& GetCentroid(const unsigned int pseudoLayer) const;
 
     /**
      *  @brief  Get the initial direction of the cluster
@@ -401,8 +401,10 @@ private:
     class SimplePoint
     {
     public:
-        double                  m_xyzPositionSums[3];           ///< The sum of the x, y and z hit positions in the pseudo layer
+        CartesianVector         m_xyzPosition;                  ///< The average x, y and z hit positions in the pseudo layer
         unsigned int            m_nHits;                        ///< The number of hits in the pseudo layer
+		//default constructor because CartesianVector doesn't have one
+		SimplePoint() : m_xyzPosition(0.f,0.f,0.f), m_nHits(0) {}
     };
 
     typedef std::map<unsigned int, SimplePoint> PointByPseudoLayerMap;///< The point by pseudo layer typedef

--- a/src/Objects/Cluster.cc
+++ b/src/Objects/Cluster.cc
@@ -160,9 +160,11 @@ StatusCode Cluster::RemoveCaloHit(const CaloHit *const pCaloHit)
     else
     {
         SimplePoint &mypoint = m_sumXYZByPseudoLayer[pseudoLayer];
-        mypoint.m_xyzPositionSums[0] = 0.f;
-        mypoint.m_xyzPositionSums[1] = 0.f;
-        mypoint.m_xyzPositionSums[2] = 0.f;
+		mypoint.m_xyzPosition.SetValues(
+                                        0.f,
+                                        0.f,
+                                        0.f
+        );
         mypoint.m_nHits = 0;
     }
 

--- a/src/Objects/Cluster.cc
+++ b/src/Objects/Cluster.cc
@@ -85,30 +85,30 @@ StatusCode Cluster::AddCaloHit(const CaloHit *const pCaloHit)
     if (pCaloHit->IsInOuterSamplingLayer()) 
         ++m_nCaloHitsInOuterLayer;
 
-    const float x(pCaloHit->GetPositionVector().GetX());
-    const float y(pCaloHit->GetPositionVector().GetY());
-    const float z(pCaloHit->GetPositionVector().GetZ());
-
     m_electromagneticEnergy += pCaloHit->GetElectromagneticEnergy();
     m_hadronicEnergy += pCaloHit->GetHadronicEnergy();
 
     const unsigned int pseudoLayer(pCaloHit->GetPseudoLayer());
     OrderedCaloHitList::const_iterator iter = m_orderedCaloHitList.find(pseudoLayer);
 
+	SimplePoint &mypoint = m_sumXYZByPseudoLayer[pseudoLayer];
+	
     if ((m_orderedCaloHitList.end() != iter) && (iter->second->size() > 1))
     {
-        SimplePoint &mypoint = m_sumXYZByPseudoLayer[pseudoLayer];
-        mypoint.m_xyzPositionSums[0] += x;
-        mypoint.m_xyzPositionSums[1] += y;
-        mypoint.m_xyzPositionSums[2] += z;
+        mypoint.m_xyzPosition.SetValues(
+                                        (mypoint.m_xyzPosition.GetX()*mypoint.m_nHits + pCaloHit->GetPositionVector().GetX())/(mypoint.m_nHits+1),
+                                        (mypoint.m_xyzPosition.GetY()*mypoint.m_nHits + pCaloHit->GetPositionVector().GetY())/(mypoint.m_nHits+1),
+                                        (mypoint.m_xyzPosition.GetZ()*mypoint.m_nHits + pCaloHit->GetPositionVector().GetZ())/(mypoint.m_nHits+1)
+        );
         ++mypoint.m_nHits;
     }
     else
     {
-        SimplePoint &mypoint = m_sumXYZByPseudoLayer[pseudoLayer];
-        mypoint.m_xyzPositionSums[0] = x;
-        mypoint.m_xyzPositionSums[1] = y;
-        mypoint.m_xyzPositionSums[2] = z;
+        mypoint.m_xyzPosition.SetValues(
+                                        pCaloHit->GetPositionVector().GetX(),
+                                        pCaloHit->GetPositionVector().GetY(),
+                                        pCaloHit->GetPositionVector().GetZ()
+        );
         mypoint.m_nHits = 1;
     }
 
@@ -140,10 +140,6 @@ StatusCode Cluster::RemoveCaloHit(const CaloHit *const pCaloHit)
     if (pCaloHit->IsInOuterSamplingLayer())
         --m_nCaloHitsInOuterLayer;
 
-    const float x(pCaloHit->GetPositionVector().GetX());
-    const float y(pCaloHit->GetPositionVector().GetY());
-    const float z(pCaloHit->GetPositionVector().GetZ());
-
     m_electromagneticEnergy -= pCaloHit->GetElectromagneticEnergy();
     m_hadronicEnergy -= pCaloHit->GetHadronicEnergy();
 
@@ -152,9 +148,11 @@ StatusCode Cluster::RemoveCaloHit(const CaloHit *const pCaloHit)
     if (m_orderedCaloHitList.end() != m_orderedCaloHitList.find(pseudoLayer))
     {
         SimplePoint &mypoint = m_sumXYZByPseudoLayer[pseudoLayer];
-        mypoint.m_xyzPositionSums[0] -= x;
-        mypoint.m_xyzPositionSums[1] -= y;
-        mypoint.m_xyzPositionSums[2] -= z;
+        mypoint.m_xyzPosition.SetValues(
+                                        (mypoint.m_xyzPosition.GetX()*mypoint.m_nHits - pCaloHit->GetPositionVector().GetX())/(mypoint.m_nHits-1),
+                                        (mypoint.m_xyzPosition.GetY()*mypoint.m_nHits - pCaloHit->GetPositionVector().GetY())/(mypoint.m_nHits-1),
+                                        (mypoint.m_xyzPosition.GetZ()*mypoint.m_nHits - pCaloHit->GetPositionVector().GetZ())/(mypoint.m_nHits-1)
+        );
         --mypoint.m_nHits;
     }
     else
@@ -213,7 +211,7 @@ StatusCode Cluster::RemoveIsolatedCaloHit(const CaloHit *const pCaloHit)
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const CartesianVector Cluster::GetCentroid(const unsigned int pseudoLayer) const
+const CartesianVector& Cluster::GetCentroid(const unsigned int pseudoLayer) const
 {
     PointByPseudoLayerMap::const_iterator pointValueIter = m_sumXYZByPseudoLayer.find(pseudoLayer);
 
@@ -224,10 +222,8 @@ const CartesianVector Cluster::GetCentroid(const unsigned int pseudoLayer) const
 
     if (0 == mypoint.m_nHits)
         throw StatusCodeException(STATUS_CODE_FAILURE);
-
-    return CartesianVector(static_cast<float>(mypoint.m_xyzPositionSums[0] / static_cast<float>(mypoint.m_nHits)),
-        static_cast<float>(mypoint.m_xyzPositionSums[1] / static_cast<float>(mypoint.m_nHits)),
-        static_cast<float>(mypoint.m_xyzPositionSums[2] / static_cast<float>(mypoint.m_nHits)));
+	
+	return mypoint.m_xyzPosition;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -443,16 +439,20 @@ StatusCode Cluster::AddHitsFromSecondCluster(const Cluster *const pCluster)
 
         if ((m_orderedCaloHitList.end() != currentIter) && (currentIter->second->size() > 1))
         {
-            mypoint.m_xyzPositionSums[0] += theirpoint.m_xyzPositionSums[0];
-            mypoint.m_xyzPositionSums[1] += theirpoint.m_xyzPositionSums[1];
-            mypoint.m_xyzPositionSums[2] += theirpoint.m_xyzPositionSums[2];
+			mypoint.m_xyzPosition.SetValues(
+                                            (mypoint.m_xyzPosition.GetX()*mypoint.m_nHits + theirpoint.m_xyzPosition.GetX()*theirpoint.m_nHits)/(mypoint.m_nHits+theirpoint.m_nHits),
+                                            (mypoint.m_xyzPosition.GetY()*mypoint.m_nHits + theirpoint.m_xyzPosition.GetY()*theirpoint.m_nHits)/(mypoint.m_nHits+theirpoint.m_nHits),
+                                            (mypoint.m_xyzPosition.GetZ()*mypoint.m_nHits + theirpoint.m_xyzPosition.GetZ()*theirpoint.m_nHits)/(mypoint.m_nHits+theirpoint.m_nHits)
+			);
             mypoint.m_nHits += theirpoint.m_nHits;
         }
         else
         {
-            mypoint.m_xyzPositionSums[0] = theirpoint.m_xyzPositionSums[0];
-            mypoint.m_xyzPositionSums[1] = theirpoint.m_xyzPositionSums[1];
-            mypoint.m_xyzPositionSums[2] = theirpoint.m_xyzPositionSums[2];
+            mypoint.m_xyzPosition.SetValues(
+                                            theirpoint.m_xyzPosition.GetX(),
+                                            theirpoint.m_xyzPosition.GetY(),
+                                            theirpoint.m_xyzPosition.GetZ()
+			);
             mypoint.m_nHits = theirpoint.m_nHits;
         }
     }


### PR DESCRIPTION
This PR modifies the Cluster class so that it keeps track of the centroid position for each pseudolayer, updating it dynamically when hits are added or removed. (A vector is also used instead of a map to keep track of the centroid positions by pseudolayer index, a modification which had previously been tested.)

Notes on CPU usage: with the CMS HGC in 140 pileup, spontaneous construction of a CartesianVector for the centroid position took ~1/3 of the time used by GetCentroid(), while the std::map search for the correct pseudolayer took ~2/3 of the time.
